### PR TITLE
fix(action): use fully-qualified bot name for image (including repo)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -104,7 +104,7 @@ runs:
         dockerfile_array=()
         for df in $dockerfiles; do
           name=$(basename "$df" | sed 's/Dockerfile\.//')
-          reg_tag=${{ inputs.registry }}/${{ env.LOWERCASE_OWNER }}/${name}:${{ inputs.tag }}
+          reg_tag=${{ env.IMAGE_NAME }}-${name:-bot}:${{ inputs.tag }}
           docker build -t "$reg_tag" -f "$df" .
           if [[ "${{ inputs.push }}" == "true" ]]; then
             docker push "$reg_tag"


### PR DESCRIPTION
use `{org}/{repo}-{name}` for image, instead of just `{org}/{name}`

`name` is `bot` if there's only one `bot.py` or `bot/__init__.py` detected (e.g. `myorg/myrepo-bot`)