### PR TITLE
refactor: use updated release of Silverback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
 
     # TODO: Can this be done using a Docker image instead?
     - name: Install Silverback
-      run: pip install "git+https://github.com/ApeWorX/silverback.git@fix/build/setuptools-scm-version"
+      run: pip install "silverback>=0.7.22"
       shell: bash
 
     - name: Log into GitHub Container Registry


### PR DESCRIPTION
Was only using a temporary branch until Silverback SDK 0.7.22 was released